### PR TITLE
CAM-10419: common configuration for dependency bom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ hs_err_pid*
 target/
 .idea/
 *.iml
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,21 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.</license.inlineHeader>
+
+    <!-- Properties for license book generation -->
+    <!-- These properties can be overridden by inheriting modules
+      to generate a list of dependencies (called BOM here) 
+      and attach it as a Maven artifact -->
+      
+    <!-- set to false to generate a third party dependency bom -->
+    <skip-third-party-bom>true</skip-third-party-bom>
+    <!-- set the Maven scopes that should be included in the dependency bom.
+      Must be a pipe-separated (|) list of Maven scopes -->
+    <third-party-bom-scopes>compile</third-party-bom-scopes>
   </properties>
 
   <build>
+    <!-- define common configuration for license checks -->
     <pluginManagement>
       <plugins>
         <!-- license plugin -->
@@ -96,6 +108,99 @@ limitations under the License.</license.inlineHeader>
         </plugin>
       </plugins>
     </pluginManagement>
+    
+    <!-- Plugins used in the context of creating a license book. -->
+    <!-- If activated (see properties), these plugins create a list of 
+      non-Camunda dependencies and attach it as an artifact to the build.
+      The license book generator uses these files to create the book. -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>list-deps</id>
+            <goals>
+              <goal>list</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <skip>${skip-third-party-bom}</skip>
+              <includeScope>test</includeScope><!-- Gives all dependencies; scopes filtering is applied in the ant step -->
+              <sort>true</sort>
+              <excludeGroupIds>org.camunda</excludeGroupIds>
+              <outputFile>${project.build.directory}/dependencies/dependencies-generated.txt</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <!-- Reformats the dependency list:
+            - into a plain list (no header line, no indentation)
+            - Filters all dependencies in unwanted scopes -->
+          <execution>
+            <id>reformat-dependencies</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+                <skip>${skip-third-party-bom}</skip>
+                <target>
+                  <copy file="${project.build.directory}/dependencies/dependencies-generated.txt" 
+                    tofile="${project.build.directory}/dependencies.txt">
+                    <filterchain>
+                      <linecontains negate="true"><!-- Remove header line -->
+                        <contains value="The following files have been resolved"/>
+                      </linecontains>
+                      <linecontainsregexp><!-- only keep the desired scopes -->
+                        <regexp pattern=":(?:${third-party-bom-scopes})$"/>
+                      </linecontainsregexp>
+                      <tokenfilter>
+                        <replaceregex pattern=":(?:${third-party-bom-scopes})$" replace="" /> <!-- Remove scope -->
+                        <trim/><!-- Remove whitespace -->
+                        <ignoreblank />
+                      </tokenfilter>
+                    </filterchain>
+                  </copy>
+                </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
+        <executions>
+          <!-- Attaches the dependency BOM to the Maven build so
+            that it can be consumed as a Maven artifact in the license book
+            module -->
+          <execution>
+            <id>attach-deps</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <skipAttach>${skip-third-party-bom}</skipAttach>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/dependencies.txt</file>
+                  <type>txt</type>
+                  <classifier>third-party-bom</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
     <licenses>


### PR DESCRIPTION
- can be activated in all inheriting modules by setting a Maven
  property. This will then generate a plain-text list of all third-
  party dependencies and attach it to the Maven build. The
  license book generator module then consumes all these BOMs

related to CAM-10419