### PR TITLE
CAM-13361: chore(license): exclude maven wrapper class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@ limitations under the License.</license.inlineHeader>
               <exclude>**/org/camunda/bpm/engine/impl/digest/_apacheCommonsCodec/*.java</exclude>
               <exclude>**/org/camunda/bpm/licensecheck/_apacheCommonsCodec/*.java</exclude>
               <exclude>**/node_modules/**</exclude>
+              <exclude>.mvn/wrapper/MavenWrapperDownloader.java</exclude>
             </excludes>
             <mapping>
               <java>SLASHSTAR_STYLE</java>


### PR DESCRIPTION
* The Maven Wrapper downloader class has a custom Apache 2.0 License header that needs to be excluded.

Related to CAM-13361