### PR TITLE
chore: upgrade camunda-release-parent to 3.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.7.2</version>
+    <version>3.7.3</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>
@@ -103,6 +103,13 @@ limitations under the License.</license.inlineHeader>
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <configuration>
+            <waitMaxTime>3600</waitMaxTime>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-release-parent/pull/54 and https://github.com/camunda/team-infrastructure/issues/833.

Upgrade `camunda-release-parent` to version `3.7.3`, which introduces the new `central-sonatype-publish` configuration to support the migration from OSSRH to the Sonatype Central Portal.