### PR TITLE
chore: upgrade camunda-release-parent to 3.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-release-parent/pull/55 and https://github.com/camunda/team-infrastructure/issues/833.

Upgrade camunda-release-parent to version 3.7.4 in sync with the migration to the Sonatype Central Portal,  introducing some [changes](https://github.com/camunda/camunda-release-parent/pull/53).