### PR TITLE
chore: upgrade camunda-release-parent to 3.7.4 (2.2)

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -2,5 +2,6 @@
 buildMavenAndDeployToMavenCentral([
   jdk:8,
   mvn:3.3,
+  mvnReleaseProfiles:'sonatype-oss-release',
   publishZipArtifactToCamundaOrg:true
 ])

--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,2 +1,6 @@
 @Library("camunda-ci") _
-buildMavenAndDeployToMavenCentral([jdk:8, publishZipArtifactToCamundaOrg:true])
+buildMavenAndDeployToMavenCentral([
+  jdk:8,
+  mvn:3.3,
+  publishZipArtifactToCamundaOrg:true
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.7.2</version>
+    <version>3.7.4</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>
@@ -100,6 +100,13 @@ limitations under the License.</license.inlineHeader>
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <configuration>
+            <waitMaxTime>3600</waitMaxTime>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-release-parent/pull/55 and https://github.com/camunda/team-infrastructure/issues/833.

Upgrade camunda-release-parent to version 3.7.4 in sync with the migration to the Sonatype Central Portal,  introducing some [changes](https://github.com/camunda/camunda-release-parent/pull/53).

Additionally:
- bump maven to 3.3
- fallback to the `sonatype-oss-release` deprecated profile (central-publishing-maven-release does not work with maven 3.3)

Test: https://stage.ci.cambpm.camunda.cloud/job/camunda-github-org/job/camunda-bpm-release-parent/view/change-requests/job/PR-15/5/console